### PR TITLE
fix: Install poetry deps into system Python in CI

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -37,6 +37,7 @@ jobs:
         run: |
           pip install --upgrade pip
           pip install poetry
+          poetry config virtualenvs.create false
           poetry install --no-interaction
           pip install plotly kaleido investing-algorithm-framework
 


### PR DESCRIPTION
## Summary

Fixes #5 — Docs pipeline failing (all 52 chart generations fail with `No module named 'scipy'`).

## Root Cause

`poetry install --no-interaction` installs all dependencies (including `scipy`) into a **poetry-managed virtualenv**. But then `python scripts/charts/generate_all.py` runs with the **system Python** — outside that venv — so every import fails.

## Fix

Added `poetry config virtualenvs.create false` before `poetry install` in `deploy-docs.yml`. This installs all packages directly into the CI runner's system Python, so `python`, `poetry install`, and `pip install` all share the same environment.

## Testing

- One-line change in CI config — no code changes
- Will be validated when the docs workflow runs on merge

Closes #5