### PR TITLE
fix: Remove redundant image copy step in docs CI

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -47,12 +47,6 @@ jobs:
       - name: Generate doc pages
         run: python scripts/generate_docs.py
 
-      # ── Copy images to Docusaurus static dir ──
-      - name: Copy indicator images to docs
-        run: |
-          mkdir -p docs/static/img/indicators
-          cp static/images/indicators/*.png docs/static/img/indicators/
-
       # ── Node: build Docusaurus ──
       - name: Set up Node.js
         uses: actions/setup-node@v4


### PR DESCRIPTION
## Summary

Fixes #7 — Docs pipeline fails because `cp` copies files onto themselves.

## Root Cause

`docs/static/img/indicators` is a **symlink** pointing to `static/images/indicators/`. The workflow step:

```yaml
cp static/images/indicators/*.png docs/static/img/indicators/
```

resolves both source and destination to the same directory. On Linux (CI runner), `cp` errors with `'X.png' and 'Y.png' are the same file` for all 52+ images.

## Fix

Removed the entire "Copy indicator images to docs" step. The symlink already makes images available to Docusaurus — no copy needed.

Closes #7